### PR TITLE
API fixes

### DIFF
--- a/examples/game_of_life/mix.exs
+++ b/examples/game_of_life/mix.exs
@@ -26,7 +26,7 @@ defmodule GameOfLife.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:popcorn, path: "../popcorn"}
+      {:popcorn, path: "../.."}
     ]
   end
 end

--- a/lib/popcorn/api/wasm.ex
+++ b/lib/popcorn/api/wasm.ex
@@ -96,8 +96,11 @@ defmodule Popcorn.Wasm do
     {:ok, message} = deserialize(raw_message)
 
     case message do
-      ["dom_event", name, data, custom] -> {:wasm_event, String.to_atom(name), data, custom}
-      cast_message -> {:wasm_cast, cast_message}
+      ["_popcorn_dom_event", name, data, custom] ->
+        {:wasm_event, String.to_atom(name), data, custom}
+
+      cast_message ->
+        {:wasm_cast, cast_message}
     end
   end
 
@@ -230,7 +233,7 @@ defmodule Popcorn.Wasm do
         return data;
       };
       const fn = (event) => {
-        wasm.cast(event_receiver, ["dom_event", event_name, getEventData(event), custom_data]);
+        wasm.cast(event_receiver, ["_popcorn_dom_event", event_name, getEventData(event), custom_data]);
       };
       const node = target_node;
       node.addEventListener(event_name, fn);


### PR DESCRIPTION
- Fix method of gathering exported beams from Popcorn library
- Prefix internal events with _popcorn in Wasm.ex
- Fix game of life popcorn dep location